### PR TITLE
bugfix: 删除时清除缓存

### DIFF
--- a/zset.lua
+++ b/zset.lua
@@ -20,6 +20,7 @@ function mt:rem(member)
     local score = self.tbl[member]
     if score then
         self.sl:delete(score, member)
+        self.tbl[member] = nil
     end
 end
 


### PR DESCRIPTION
```
local zset = require "zset"                                                                                                                                                                
local zs = zset.new()                                                                                                                                                                      
zs:add(1, 'p1')                                                                                                                                                                            
zs:add(2, 'p2')                                                                                                                                                                            
zs:add(3, 'p3')                                                                                                                                                                            
print(zs:rev_rank('p3'))                                                                                                                                                                   
zs:rem('p3')                                                                                                                                                                               
print(zs:rev_rank('p3'))                                                                                                                                                                   
zs:add(3, 'p3')                                                                                                                                                                            
print(zs:rev_rank('p3'))  -- the result is nil!!!
```
