### PR TITLE
add member_by_rank/member_by_rev_rank

### DIFF
--- a/lua-skiplist.c
+++ b/lua-skiplist.c
@@ -153,6 +153,18 @@ _get_score_range(lua_State *L) {
 }
 
 static int
+_get_member_by_rank(lua_State *L){
+    skiplist *sl = _to_skiplist(L);
+    unsigned long r = luaL_checkinteger(L, 2);
+    skiplistNode *node = slGetNodeByRank(sl, r);
+    if (node) {
+        lua_pushlstring(L, node->obj->ptr, node->obj->length);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 _dump(lua_State *L) {
     skiplist *sl = _to_skiplist(L);
     slDump(sl);
@@ -190,6 +202,7 @@ int luaopen_skiplist_c(lua_State *L) {
         {"get_rank", _get_rank},
         {"get_rank_range", _get_rank_range},
         {"get_score_range", _get_score_range},
+        {"get_member_by_rank", _get_member_by_rank},
 
         {"dump", _dump},
         {NULL, NULL}

--- a/test.lua
+++ b/test.lua
@@ -52,3 +52,13 @@ zs:dump()
 print("------------------ dump after rev limit 5 ------------------")
 zs:rev_limit(5)
 zs:dump()
+
+print("------------------ member_by_rank ------------------")
+for rank = 1, 10 do
+    print("rank", rank, zs:member_by_rank(rank))
+end
+
+print("------------------ member_by_rev_rank ------------------")
+for rank = 1, 10 do
+    print("rank", rank, zs:member_by_rev_rank(rank))
+end

--- a/zset.lua
+++ b/zset.lua
@@ -66,8 +66,8 @@ function mt:rev_limit(count, delete_handler)
 end
 
 function mt:rev_range(r1, r2)
-    local r1 = self:_reverse_rank(r1)
-    local r2 = self:_reverse_rank(r2)
+    r1 = self:_reverse_rank(r1)
+    r2 = self:_reverse_rank(r2)
     return self:range(r1, r2)
 end
 
@@ -104,6 +104,17 @@ end
 
 function mt:score(member)
     return self.tbl[member]
+end
+
+function mt:member_by_rank(r)
+    return self.sl:get_member_by_rank(r)
+end
+
+function mt:member_by_rev_rank(r)
+    r = self:_reverse_rank(r)
+    if r > 0 then
+        return self.sl:get_member_by_rank(r)
+    end
 end
 
 function mt:dump()


### PR DESCRIPTION
新增两个函数：
* member_by_rank(r) 根据指定排行取 member
* member_by_rev_rank(r) 根据指定倒序排行取 member

之前想要取指定排行，用的是 range(r, r)，两个参数传一样的，再返回个 table 出来，这里白白构造了个表出来，为了节约性能，加上了这两个函数。
