### PR TITLE
Makefile 支持 macOS；delete_handler 改为 zset.new 时传入

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -14,7 +14,11 @@ local function random_choose(t)
     return table.remove(t, i)
 end
 
-local zs = zset.new()
+local function delete_handler(member)
+	print("delete", member)
+end
+
+local zs = zset.new(delete_handler)
 
 while true do
     local score = random_choose(all)

--- a/zset.lua
+++ b/zset.lua
@@ -23,14 +23,8 @@ function mt:rem(member)
     end
 end
 
-function mt:rem_range_by_score(min, max, delete_handler)
-    local delete_function = function(member)
-        self.tbl[member] = nil
-        if delete_handler then
-            delete_handler(member)
-        end
-    end
-    return self.sl:delete_by_score(min, max, delete_function)
+function mt:rem_range_by_score(min, max)
+    return self.sl:delete_by_score(min, max, self.delete_function)
 end
 
 function mt:count()
@@ -41,38 +35,22 @@ function mt:_reverse_rank(r)
     return self.sl:get_count() - r + 1
 end
 
-function mt:limit(count, delete_handler)
+function mt:limit(count)
     local total = self.sl:get_count()
     if total <= count then
         return 0
     end
-
-    local delete_function = function(member)
-        self.tbl[member] = nil
-        if delete_handler then
-            delete_handler(member)
-        end
-    end
-
-    return self.sl:delete_by_rank(count+1, total, delete_function)
+    return self.sl:delete_by_rank(count+1, total, self.delete_function)
 end
 
-function mt:rev_limit(count, delete_handler)
+function mt:rev_limit(count)
     local total = self.sl:get_count()
     if total <= count then
         return 0
     end
     local from = self:_reverse_rank(count+1)
     local to   = self:_reverse_rank(total)
-
-    local delete_function = function(member)
-        self.tbl[member] = nil
-        if delete_handler then
-            delete_handler(member)
-        end
-    end
-
-    return self.sl:delete_by_rank(from, to, delete_function)
+    return self.sl:delete_by_rank(from, to, self.delete_function)
 end
 
 function mt:rev_range(r1, r2)
@@ -132,10 +110,16 @@ function mt:dump()
 end
 
 local M = {}
-function M.new()
+function M.new(delete_handler)
     local obj = {}
     obj.sl = skiplist()
     obj.tbl = {}
+    obj.delete_function = function(member)
+        obj.tbl[member] = nil
+        if delete_handler then
+            delete_handler(member)
+        end
+    end
     return setmetatable(obj, mt)
 end
 return M


### PR DESCRIPTION
# 问题
目前的 `delete_handler` 在每次调用删除接口时都要传入，有以下问题：
1. 违反了 DRY 原则，delete_function 的定义出现了多次。
2. 每次删除时需要创建一个临时闭包，这个开销是不必要的。
3. 接口设计不是很合理，对于一个特定的 zset 实例来说，其 delete_handler 应该是固定的，不存在每次删除时需要传入不同函数的需求。改为构造时传入，每次删除时只需要传入跟删除范围相关的参数就好了，不需要传入 `delete_handler`。

# 修改内容
这个 PR 把 `delete_handler` 移到了构造时传入，解决了上述问题。

新的用法：
```lua
local function delete_handler(member)
	print("delete", member)
end

local zs = zset.new(delete_handler)
-- ...
zs:limit(10)
zs:rev_limit(10)
zs:rem_range_by_score(1, 10)
```

# 可能的负面影响
由于修改了接口约定，以前使用旧的方式传入 `delete_handler` 的老代码会受到影响，导致 `delete_handler` 不被调用。

但是由于改起来很容易，且修改后会带来实质的性能提升，所以问题不是特别大。一般老项目不也会随便升级第3方库。
