### PR TITLE
Move delete_handler to options

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -15,10 +15,12 @@ local function random_choose(t)
 end
 
 local function delete_handler(member)
-	print("delete", member)
+    print("delete", member)
 end
 
-local zs = zset.new(delete_handler)
+local zs = zset.new {
+    delete_handler = delete_handler,
+}
 
 while true do
     local score = random_choose(all)

--- a/zset.lua
+++ b/zset.lua
@@ -110,17 +110,26 @@ function mt:dump()
 end
 
 local M = {}
-function M.new(delete_handler)
+
+---@class zset.options
+---@field delete_handler fun(member:string)
+
+--- Create a new zset
+---@param options zset.options
+function M.new(options)
     local obj = {}
     obj.sl = skiplist()
     obj.tbl = {}
+
+    local delete_handler = options and options.delete_handler
     obj.delete_function = function(member)
         obj.tbl[member] = nil
         if delete_handler then
             delete_handler(member)
         end
     end
+
     return setmetatable(obj, mt)
 end
-return M
 
+return M


### PR DESCRIPTION
# Why submit this PR?
https://github.com/xjdrew/lua-zset/pull/16#issuecomment-2123816639

# 参数名使用 `options` 的原因
这个参数表示一组选项，而不是单独的一个选项。使用复数形式更加准确地描述了它的性质。
同时也可以提高代码的可读性，比如：
```lua
for _, option in pairs(options) do
end

local option = options[xxx]
```

没有使用 `opts`，因为 `options` 本身不是很长，没必要缩写。虽然很多库都使用 opts 作为选项参数名，但严格来说这是一种有损压缩，只有知道这个惯例的人才看的懂。

# 参数标注
对于 `options` 参数的说明，使用了 Emmylua 的[标注](https://emmylua.github.io/annotation.html)。
好处是直观/易懂，且对于使用了 Emmylua 插件的同学来说，还可以智能提示。
