### PR TITLE
slGetRank compare判断错误

### DIFF
--- a/skiplist.c
+++ b/skiplist.c
@@ -262,7 +262,7 @@ unsigned long slGetRank(skiplist *sl, double score, slobj *o, double timestamp) 
 
     x = sl->header;
     for (i = sl->level-1; i >= 0; i--) {
-        while (x->level[i].forward && compare(x->level[i].forward, score, o, timestamp) < 0) {
+        while (x->level[i].forward && compare(x->level[i].forward, score, o, timestamp) <= 0) {
             rank += x->level[i].span;
             x = x->level[i].forward;
         }


### PR DESCRIPTION
# 问题
slGetRank通过member返回的位置为nil

# 测试用例
```lua
local c = require "skiplist.c"

local score = 1
local member = "a1"
local ts = 123456

local sl = c()
sl:insert(score, member, ts)
sl:dump()

local rank = sl:get_rank(score, member, ts)
print("get rank :", member, rank)

print("\n")
```

# 用例输出结果
```bash
node 1: score:1.000000, member:a1 ts:123456.000000
get rank :      a1      nil
```


# 解决过程
#18 在新ts功能时，针对slGetRank的优化后。改变了原来`<=`的判断，导致找不到匹配
https://github.com/xjdrew/lua-zset/commit/167fcfff3ff2ff1d5f8f49c9681209f71a56080a#diff-2576a617a0dd40834fc62ad52100137d899935130b1ac1847a3be1ac7d91fbd6L266

<img width="779" height="196" alt="图片" src="https://github.com/user-attachments/assets/5d83eda7-a966-4936-9502-70b7919d8df9" />

<img width="2043" height="379" alt="图片" src="https://github.com/user-attachments/assets/ab953de8-a5b0-4aeb-b7b1-59baca5191ba" />
