### PR TITLE
fix: skip compare ts 错误 & 删除遗漏的ts 释放

### DIFF
--- a/skiplist.c
+++ b/skiplist.c
@@ -90,7 +90,7 @@ int equalslObj(slobj *a, slobj *b) {
 }
 
 int compare(skiplistNode *node, double score, slobj *obj, double timestamp) {
-    int cmp = score != node->score ? node->score - score : node->timestamp - timestamp;
+    int cmp = score != node->score ? node->score - score : timestamp - node->timestamp;
     if (cmp != 0) return cmp;
 
     return compareslObj(node->obj,obj);

--- a/zset.lua
+++ b/zset.lua
@@ -8,7 +8,7 @@ function mt:add(score, member, ts)
         if old == score then
             return
         end
-        self.sl:delete(old, member)
+        self.sl:delete(old, member, self.ts[member])
     end
 
     self.sl:insert(score, member, ts)
@@ -119,6 +119,7 @@ function M.new(delete_handler)
     obj.ts = {}
     obj.delete_function = function(member)
         obj.tbl[member] = nil
+        obj.ts[member] = nil
         if delete_handler then
             delete_handler(member)
         end


### PR DESCRIPTION
1. 修改compare ts 错误
示例
```
local zs = zset:new()
zs:add(1, "a", 1)
zs:add(1, "b", 2)
zs:add(1, "c", 1)
zs:add(2, "d", 1)
```
正向排序结果： b,a,c,d
当前错误结果：a,c,b,d

2. update 时保证 delete一致 
3. trim时lua ts泄露